### PR TITLE
fixes link for Places to Study on main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Congratulations and welcome to Ada Developers Academy! This guide was written by
   - [Biking in Seattle](/car_to_bike.md)
   - [Public Transit][orcalift]
   - [Bringing A Pet][pet]
-  - [Places To Study in Seattle][/places_to_study]
+  - [Places To Study in Seattle](/places_to_study)
 
 
 


### PR DESCRIPTION
The link should now work.  This can be seen/validated here "https://github.com/Oh-KPond/Guide-for-Transplants/blob/hot-fix_places-to-study-link/README.md"