### PR TITLE
adds file ending to correct link for 'places_to_study'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Congratulations and welcome to Ada Developers Academy! This guide was written by
   - [Biking in Seattle](/car_to_bike.md)
   - [Public Transit][orcalift]
   - [Bringing A Pet][pet]
-  - [Places To Study in Seattle](/places_to_study)
+  - [Places To Study in Seattle](/places_to_study.md)
 
 
 


### PR DESCRIPTION
@susanev turns out that the file ending was not on the link for the new readme 'places_to_study' and creating a 404.  You can validate the update to correct the link here https://github.com/Oh-KPond/Guide-for-Transplants/tree/hot-fix_main_readme_link